### PR TITLE
Removed code smell in TokenMarker and added testing

### DIFF
--- a/org/gjt/sp/jedit/syntax/TokenMarker.java
+++ b/org/gjt/sp/jedit/syntax/TokenMarker.java
@@ -232,21 +232,7 @@ main_loop:	for(pos = line.offset; pos < lineLength; pos++)
 		markKeyword(true);
 		//}}}
 
-		//{{{ Unwind any NO_LINE_BREAK parent delegates
-unwind:		while(context.parent != null)
-		{
-			ParserRule rule = context.parent.inRule;
-			if((rule != null && (rule.action
-				& ParserRule.NO_LINE_BREAK) == ParserRule.NO_LINE_BREAK)
-				|| terminated)
-			{
-				context = context.parent;
-				keywords = context.rules.getKeywords();
-				context.setInRule(null);
-			}
-			else
-				break unwind;
-		} //}}}
+		context = unwind(terminated, context);
 
 		tokenHandler.handleToken(line,Token.END,
 			pos - line.offset,0,context);
@@ -260,6 +246,25 @@ unwind:		while(context.parent != null)
 
 		return context;
 	} //}}}
+
+	LineContext unwind(boolean terminated, LineContext context) {
+		//{{{ Unwind any NO_LINE_BREAK parent delegates
+		unwindlabel:		while(context.parent != null)
+				{
+					ParserRule rule = context.parent.inRule;
+					if((rule != null && (rule.action
+						& ParserRule.NO_LINE_BREAK) == ParserRule.NO_LINE_BREAK)
+						|| terminated)
+					{
+						context = context.parent;
+						keywords = context.rules.getKeywords();
+						context.setInRule(null);
+					}
+					else
+						break unwindlabel;
+				} //}}}
+		return context;
+	}
 
 	//{{{ Private members
 

--- a/org/gjt/sp/jedit/syntax/TokenMarker.java
+++ b/org/gjt/sp/jedit/syntax/TokenMarker.java
@@ -249,7 +249,7 @@ main_loop:	for(pos = line.offset; pos < lineLength; pos++)
 
 	LineContext unwind(boolean terminated, LineContext context) {
 		//{{{ Unwind any NO_LINE_BREAK parent delegates
-		unwindlabel:		while(context.parent != null)
+		while(context.parent != null)
 				{
 					ParserRule rule = context.parent.inRule;
 					if((rule != null && (rule.action
@@ -261,7 +261,7 @@ main_loop:	for(pos = line.offset; pos < lineLength; pos++)
 						context.setInRule(null);
 					}
 					else
-						break unwindlabel;
+						return context;
 				} //}}}
 		return context;
 	}

--- a/test/org/gjt/sp/jedit/syntax/TokenMarkerTest.java
+++ b/test/org/gjt/sp/jedit/syntax/TokenMarkerTest.java
@@ -25,23 +25,165 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.*;
 
 public class TokenMarkerTest {
-
+    // Use these to set the spanEndSubst attribute uniquely and then use its value to determine if
+    // the unwind was done properly
+    char[] line1Pattern = new char[]{'f', 'i', 'r', 's', 't'};
+    char[] line2Pattern = new char[]{'s', 'e', 'c', 'o', 'n', 'd'};
+    char[] line3Pattern = new char[]{'t', 'h', 'i', 'r', 'd'};
+    ParserRuleSet rules;
+    TokenMarker tokenMarker;
 
     @Before
     public void setUp() {
-        //TokenMarker tokenMark = new TokenMarker();
+        rules = new ParserRuleSet("text","MAIN");
+        tokenMarker = new TokenMarker();
+        tokenMarker.addRuleSet(rules);
     }
 
     @After
     public void tearDown() {
     }
 
-    @Test
-    public void emptyTest() {
-        assertEquals(10, 10);
+    protected ParserRule createRuleNoLineBreak(ParserRuleSet rules) {
+    // Set up parent rule to contain NO_LINE_BREAK which enables an unwind
+        byte id = 0;
+        byte matchType = 0;
+        ParserRule rule = ParserRule.createSpanRule(0, "start", 1,
+            "end", rules, id, matchType, true, false, "");
+        return rule;
     }
 
+    @Test
+    public void noUnwindNullParentTest() {
+    // No parent or previous line to parse so check that we don't "unwind" and go back to previous line
+
+        // The context attribute is private in the TokenMarker field, so this test method cannot
+        // set its value.  Instead we've created a LineContext and will access it directly since its
+        // attributes are public.
+
+        // No parent so we won't unwind
+        TokenMarker.LineContext parent = null;
+        TokenMarker.LineContext child = new TokenMarker.LineContext(rules,parent);
+        child.spanEndSubst = line1Pattern;
+
+        // Set compareLC to a clone of the expected results after unwinding
+        TokenMarker.LineContext compareLC = (TokenMarker.LineContext) child.clone();
+
+        // The null value of parent will keep us from unwinding so just set terminated to some value
+        boolean terminated = true;
+
+        TokenMarker.LineContext processedLC = tokenMarker.unwind(terminated, child);
+
+        assertTrue(processedLC.equals(compareLC));
+    }
+
+    @Test
+    public void noUnwindNullRuleTest() {
+        // Create a parent LineContext and child LineContext and link them together
+        // through the child's parent attribute
+        TokenMarker.LineContext parent = new TokenMarker.LineContext(rules,null);
+        parent.spanEndSubst = line2Pattern;
+        //Link the parent to the child
+        TokenMarker.LineContext child = new TokenMarker.LineContext(rules,parent);
+        child.spanEndSubst = line1Pattern;
+
+        // Set processedLC to a clone of the expected results after unwinding
+        TokenMarker.LineContext compareLC = (TokenMarker.LineContext) child.clone();
+
+        // Set up terminated to block unwind
+        boolean terminated = false;
+        // Set up rule to disable unwind
+        parent.setInRule(null);
+        TokenMarker.LineContext processedLC = tokenMarker.unwind(terminated, child);
+
+        assertTrue(processedLC.equals(compareLC));
+    }
+
+        @Test
+    public void unwindTest() {
+        // Create a parent LineContext and child LineContext and link them together
+        // through the child's parent attribute
+        TokenMarker.LineContext parent = new TokenMarker.LineContext(rules,null);
+        parent.spanEndSubst = line2Pattern;
+        // Set compareLC to a clone of the expected results after unwinding
+        // Need to make a clone before we add the ParserRule since that is set to null when unwinding
+        TokenMarker.LineContext compareLC = (TokenMarker.LineContext) parent.clone();
+        // Set up parser rule with NO_LINE_BREAK action
+        ParserRule parentRule = createRuleNoLineBreak(rules);
+        parent.setInRule(parentRule);
+
+        // create child and link to the parent
+        TokenMarker.LineContext child = new TokenMarker.LineContext(rules,parent);
+        child.spanEndSubst = line1Pattern;
+
+        // Set up terminated to block unwind
+        boolean terminated = false;
+
+        TokenMarker.LineContext processedLC = tokenMarker.unwind(terminated, child);
+
+        assertTrue(Arrays.equals(line2Pattern,processedLC.spanEndSubst));
+        assertTrue(processedLC.equals(compareLC));
+
+    }
+
+    @Test
+    public void unwind1Test() {
+        // Create three LineContext link them together through the child's parent attribute
+        // Only the middle LineContext will contain a rule so unwind should only step back to middle LineContext
+        TokenMarker.LineContext grandparent = new TokenMarker.LineContext(rules,null);
+        grandparent.spanEndSubst = line3Pattern;
+        grandparent.setInRule(null);
+
+        TokenMarker.LineContext parent = new TokenMarker.LineContext(rules,grandparent);
+        parent.spanEndSubst = line2Pattern;
+        ParserRule parentRule = createRuleNoLineBreak(rules);
+        parent.setInRule(parentRule);
+
+        TokenMarker.LineContext child = new TokenMarker.LineContext(rules,parent);
+        child.spanEndSubst = line1Pattern;
+        child.setInRule(null);
+
+        // Set compareLC to a clone of the expected results after unwinding
+        TokenMarker.LineContext compareLC = (TokenMarker.LineContext) child.parent.clone();
+        // Need to reset ParserRule to null since unwind will also do that
+        compareLC.setInRule(null);
+
+        // Set up terminated to block unwind
+        boolean terminated = false;
+
+        TokenMarker.LineContext processedLC = tokenMarker.unwind(terminated, child);
+
+        assertTrue(Arrays.equals(line2Pattern,processedLC.spanEndSubst));
+        assertTrue(processedLC.equals(compareLC));
+
+    }
+
+    @Test
+    public void unwindTerminatedTest() {
+        // Create a parent LineContext and child LineContext and link them together
+        // through the child's parent attribute
+        TokenMarker.LineContext parent = new TokenMarker.LineContext(rules,null);
+        parent.spanEndSubst = line2Pattern;
+        parent.setInRule(null);
+
+        //Link the parent to the child
+        TokenMarker.LineContext child = new TokenMarker.LineContext(rules,parent);
+        child.spanEndSubst = line1Pattern;
+
+        // Set up terminated to enable unwind
+        boolean terminated = true;
+
+        // Set compareLC to a clone of the expected results after unwinding
+        TokenMarker.LineContext compareLC = (TokenMarker.LineContext) parent.clone();
+
+        TokenMarker.LineContext processedLC = tokenMarker.unwind(terminated, child);
+
+        assertTrue(Arrays.equals(line2Pattern,processedLC.spanEndSubst));
+        assertTrue(processedLC.equals(compareLC));
+;    }
 }


### PR DESCRIPTION
Removed a code smell involving the use of a labeled break statement.  Extracted the code from markTokens() into its own method - unwind().  
Added 6 JUnit tests to cover each possible branch of code in unwind().